### PR TITLE
feat: implement functional contact form with EmailJS integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "beautiful-portfolio",
       "version": "0.0.0",
       "dependencies": {
+        "@emailjs/browser": "^4.4.1",
         "@radix-ui/react-toast": "^1.2.10",
         "@tailwindcss/vite": "^4.1.4",
         "class-variance-authority": "^0.7.1",
@@ -314,6 +315,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
+      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emailjs/browser": "^4.4.1",
     "@radix-ui/react-toast": "^1.2.10",
     "@tailwindcss/vite": "^4.1.4",
     "class-variance-authority": "^0.7.1",

--- a/src/components/ContactSection.jsx
+++ b/src/components/ContactSection.jsx
@@ -11,24 +11,68 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import emailjs from "@emailjs/browser";
 
 export const ContactSection = () => {
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    message: "",
+  });
 
-  const handleSubmit = (e) => {
+  // Inicializar EmailJS
+  useEffect(() => {
+    emailjs.init("tTpNUocwJwuhtIQGD");
+  }, []);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-
     setIsSubmitting(true);
 
-    setTimeout(() => {
+    try {
+      // Configuração do EmailJS
+      const templateParams = {
+        from_name: formData.name,
+        from_email: formData.email,
+        message: formData.message,
+        to_name: "Yago Castelao",
+      };
+
+      await emailjs.send(
+        "service_4607px9",
+        "template_8o295lq",
+        templateParams
+      );
+
       toast({
-        title: "Message sent!",
+        title: "Message sent successfully!",
         description: "Thank you for your message. I'll get back to you soon.",
       });
+
+      // Limpar formulário
+      setFormData({ name: "", email: "", message: "" });
+    } catch (error) {
+      console.error("EmailJS Error:", error);
+      toast({
+        title: "Error sending message",
+        description:
+          "Something went wrong. Please try again or contact me directly.",
+        variant: "destructive",
+      });
+    } finally {
       setIsSubmitting(false);
-    }, 1500);
+    }
   };
   return (
     <section id="contact" className="py-24 px-4 relative bg-secondary/30">
@@ -60,7 +104,7 @@ export const ContactSection = () => {
                     href="mailto:yago_castelau@hotmail.com"
                     className="text-muted-foreground hover:text-primary transition-colors"
                   >
-                    yago_castelau@hotmail.com
+                    yago.castelao@icloud.com
                   </a>
                 </div>
               </div>
@@ -69,7 +113,7 @@ export const ContactSection = () => {
                   <Phone className="h-6 w-6 text-primary" />{" "}
                 </div>
                 <div>
-                  <h4 className="font-medium"> Phone</h4>
+                  <h4 className="font-medium"> Phone & Whatsapp</h4>
                   <a
                     href="tel:+34692289484"
                     className="text-muted-foreground hover:text-primary transition-colors"
@@ -103,7 +147,10 @@ export const ContactSection = () => {
                 <a href="https://x.com/yagocastelau" target="_blank">
                   <Twitter />
                 </a>
-                <a href="https://www.instagram.com/yagocastelao" target="_blank">
+                <a
+                  href="https://www.instagram.com/yagocastelao"
+                  target="_blank"
+                >
                   <Instagram />
                 </a>
                 <a href="https://github.com/YagoCastelao" target="_blank">
@@ -132,6 +179,8 @@ export const ContactSection = () => {
                   type="text"
                   id="name"
                   name="name"
+                  value={formData.name}
+                  onChange={handleInputChange}
                   required
                   className="w-full px-4 py-3 rounded-md border border-input bg-background focus:outline-hidden foucs:ring-2 focus:ring-primary"
                   placeholder="Yago Cima Castelao..."
@@ -150,9 +199,11 @@ export const ContactSection = () => {
                   type="email"
                   id="email"
                   name="email"
+                  value={formData.email}
+                  onChange={handleInputChange}
                   required
                   className="w-full px-4 py-3 rounded-md border border-input bg-background focus:outline-hidden foucs:ring-2 focus:ring-primary"
-                  placeholder="yago_castelau@hotmail.com"
+                  placeholder="yago.castelao@icloud.com"
                 />
               </div>
 
@@ -167,7 +218,10 @@ export const ContactSection = () => {
                 <textarea
                   id="message"
                   name="message"
+                  value={formData.message}
+                  onChange={handleInputChange}
                   required
+                  rows="6"
                   className="w-full px-4 py-3 rounded-md border border-input bg-background focus:outline-hidden foucs:ring-2 focus:ring-primary resize-none"
                   placeholder="Hello, I'd like to talk about..."
                 />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -46,7 +46,7 @@ export const Navbar = () => {
             <a
               key={key}
               href={item.href}
-              className="text-foreground/80 hover:text-primary transition-colors duration-300"
+              className="text-foreground/80 hover:text-primary transition-colors duration-300 font-semibold"
             >
               {item.name}
             </a>

--- a/src/components/ProjectsSection.jsx
+++ b/src/components/ProjectsSection.jsx
@@ -63,8 +63,11 @@ export const ProjectsSection = () => {
 
               <div className="p-6">
                 <div className="flex flex-wrap gap-2 mb-4">
-                  {project.tags.map((tag) => (
-                    <span className="px-2 py-1 text-xs font-medium border rounded-full bg-secondary text-secondary-foreground">
+                  {project.tags.map((tag, tagIndex) => (
+                    <span
+                      key={tagIndex}
+                      className="px-2 py-1 text-xs font-medium border rounded-full bg-secondary text-secondary-foreground"
+                    >
                       {tag}
                     </span>
                   ))}

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -32,7 +32,7 @@ export const ThemeToggle = () => {
     <button
       onClick={toggleTheme}
       className={cn(
-        "fixed max-sm:hidden top-5 right-5 z-50 p-2 rounded-full transition-colors duration-300",
+        "fixed max-sm:hidden top-3 right-7 z-50 p-2 rounded-full transition-colors duration-300",
         "focus:outlin-hidden"
       )}
     >


### PR DESCRIPTION
- Add EmailJS integration for contact form functionality
- Install @emailjs/browser package for email sending capabilities
- Configure EmailJS service with iCloud SMTP settings
- Create responsive email template with professional styling and branding
- Implement form state management with controlled inputs
- Add form validation and error handling with toast notifications
- Fix React keys warning in ProjectsSection tags mapping
- Initialize EmailJS with public key in useEffect hook
- Configure proper email routing (from: yago.castelao@icloud.com, reply-to: user email)
- Add loading state and form reset after successful submission
- Create comprehensive setup documentation (EMAIL_SETUP.md)
- Generate HTML email template with gradient design and professional layout

Breaking changes: None
Fixes: Contact form now sends real emails instead of mock functionality